### PR TITLE
 Fix different encodings on datamatrix barcodes

### DIFF
--- a/elaphe/datamatrix.py
+++ b/elaphe/datamatrix.py
@@ -129,7 +129,7 @@ class DataMatrix(Barcode):
                         cw_length+=2
                         residue = residue[1:]
             elif encoding in ['c40', 'text', 'x12']:
-                enc_props = dict(
+                enc_types = dict(
                     c40=dict(
                         mode=230, eightbits=True,
                         charmap=(
@@ -164,6 +164,7 @@ class DataMatrix(Barcode):
                             '1d1e1f2021222324252627ffffffffff'
                             'ffffffffffffffffffffffffffffffff'
                             'ffffffffffffffffffffffffffffffff')))
+                enc_props = enc_types.get(encoding)
                 parsefnc = enc_props.get('parsefnc', parsefnc)
                 mode = enc_props.get('mode')
                 eightbits = enc_props.get('eightbits')


### PR DESCRIPTION
Specifying an alternate encoding was raising an exception instead of
changing the encoding.

Specifying an alternate encoding was raising an exception instead of changing the encoding.
This fixes issue #86 - https://bitbucket.org/whosaysni/elaphe/issues/86/datamatrix-c40-encoding-not-working
