### PR TITLE
Removing unmacthed parenthesis from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ The following example::
   >>> barcode('qrcode',
   ...         'Hello Barcode Writer In Pure PostScript.',
   ...         options=dict(version=9, eclevel='M'), 
-  ...         margin=10, data_mode='8bits'))   # Generates PIL.EpsImageFile instance
+  ...         margin=10, data_mode='8bits')   # Generates PIL.EpsImageFile instance
   <PIL.EpsImagePlugin.EpsImageFile ... at ...>
   >>> _.show() # Show rendered bitmap
 


### PR DESCRIPTION
There was an unmatched parenthesis at the end of the "barcode" function that could cause confusion.