### PR TITLE
Improve resource handling in utils

### DIFF
--- a/elaphe/util.py
+++ b/elaphe/util.py
@@ -178,8 +178,8 @@ def distill_ps_code(path_to_ps_code=DEFAULT_PS_CODE_PATH,
     <BLANKLINE>
     <BLANKLINE>
     """
-    return distill_regexp.findall(
-        open(path_to_ps_code, 'r').read())[0].replace('%', '%%')
+    with open(path_to_ps_code, 'r') as f:
+        return distill_regexp.findall(f.read())[0].replace('%', '%%')
 
 
 DEFAULT_EPSF_DSC_TEMPLATE = """%%!PS-Adobe-2.0


### PR DESCRIPTION
This avoids leading a file handle ever time `distill_ps_code` is called, which is at least twice when the utils file is imported.